### PR TITLE
EASY-1945 Upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ It can happen that a dependency is included in one of the parent POMs, that also
 
 1. Test that the `SNAPSHOT` version of the parent POM with reference to the latest `SNAPSHOT` version of the dependency is behaving as expected.
 2. In the parent POM, change the version number for the dependency to the next (not yet deployed) release version.
-3. Build and deploy `dans-parent-pom`.
+3. Release `dans-parent-pom` and deploy it to the Maven repository.
 4. In the dependency's POM, change the parent POM version number to the newly deployed version of `dans-parent-pom`.
 5. Build and deploy the inheriting project.
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ declared in the parent, using the `combine.*` attributes. (See [the Maven POM re
 Currently, the DANS repositories don't host any plug-ins. Not entirely true: for a few legacy projects we host patched third-party plug-ins. In those
 cases the above `<repositories>`-element must be copied and adjusted to a `<pluginRepositories>` element as well.
 
+HANDLING CIRCULAR DEPENDENCIES
+------------------------------
+It can happen that a dependency is included in one of the parent POMs, that also inherits from the same parent pom. Currently this is the case for `dans-scala-lib` and `dans-bag-lib`. To avoid redundant deploys, these circular dependencies should be handled as follows:
+
+1. Test that the `SNAPSHOT` version of the parent POM with reference to the latest `SNAPSHOT` version of the dependency is behaving as expected.
+2. In the parent POM, change the version number for the dependency to the next (not yet deployed) release version.
+3. Build and deploy `dans-parent-pom`.
+4. In the dependency's POM, change the parent POM version number to the newly deployed version of `dans-parent-pom`.
+5. Build and deploy the dependency.
+
 BUILDING FROM SOURCE
 --------------------
 Prerequisites:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ It can happen that a dependency is included in one of the parent POMs, that also
 2. In the parent POM, change the version number for the dependency to the next (not yet deployed) release version.
 3. Build and deploy `dans-parent-pom`.
 4. In the dependency's POM, change the parent POM version number to the newly deployed version of `dans-parent-pom`.
-5. Build and deploy the dependency.
+5. Build and deploy the inheriting project.
 
 BUILDING FROM SOURCE
 --------------------

--- a/dans-java-project/pom.xml
+++ b/dans-java-project/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-mvn-lib-defaults</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../dans-mvn-lib-defaults</relativePath>
     </parent>
 
     <artifactId>dans-java-project</artifactId>
-    <version>5.1.4-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <name>DANS Java Project</name>
     <description>
         A bare bones Java-based project.

--- a/dans-mvn-base/pom.xml
+++ b/dans-mvn-base/pom.xml
@@ -21,7 +21,7 @@
     <groupId>nl.knaw.dans.shared</groupId>
     <artifactId>dans-mvn-base</artifactId>
     <name>DANS Maven Project Basic Settings</name>
-    <version>5.1.4-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         Parent project for all DANS Maven-based projects.
@@ -40,7 +40,7 @@
         <license-maven-plugin.version>3.0</license-maven-plugin.version>
 
         <!-- Releasing to the DANS Maven repository -->
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
 
         <snapshot-repository>http://nexus.dans.knaw.nl/repository/maven-snapshots</snapshot-repository>
         <release-repository>http://nexus.dans.knaw.nl/repository/maven-releases</release-repository>

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -92,7 +92,7 @@
         <easymock.version>4.2</easymock.version>
         <powermock.version>2.0.5</powermock.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <scala-test.version>3.2.0-SNAP10</scala-test.version>
+        <scala-test.version>3.0.8</scala-test.version>
         <scalamock.version>4.4.0</scalamock.version>
         <scalacheck.version>1.14.3</scalacheck.version>
         <cats-scalatest.version>3.0.5</cats-scalatest.version>

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -73,12 +73,14 @@
         <javax-servlet-api.version>4.0.1</javax-servlet-api.version>
         <scalatra.version>2.7.0-RC1</scalatra.version>
         <guava.version>28.2-jre</guava.version>
+        <velocity.version>1.7</velocity.version>
 
         <!-- Database connectivity -->
         <postgresql.version>42.2.10.jre7</postgresql.version>
         <sqlite.version>3.30.1</sqlite.version>
         <hsqldb.version>2.5.0</hsqldb.version>
         <hibernate.version>6.0.0.Alpha4</hibernate.version>
+        <solr4j.version>6.6.0</solr4j.version>
 
         <!-- Formats -->
         <bagit.version>5.2.0</bagit.version>
@@ -87,12 +89,14 @@
         <json4s.version>3.7.0-M2</json4s.version>
         <tika.version>1.23</tika.version>
         <dans-bag-lib.version>1.0.0-SNAPSHOT</dans-bag-lib.version>
+        <jaxen.version>1.2.0</jaxen.version>
 
         <!-- Unit testing -->
         <junit.version>4.13</junit.version>
         <junit-addons.version>1.4</junit-addons.version>
         <easymock.version>4.2</easymock.version>
         <powermock.version>2.0.5</powermock.version>
+        <mockwebserver.version>4.4.0</mockwebserver.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- Do not update untill this issue is resolved: https://github.com/scalatest/scalatest/issues/1734 -->
         <scala-test.version>3.0.8</scala-test.version> 
@@ -165,6 +169,11 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
@@ -300,6 +309,11 @@
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.velocity</groupId>
+                <artifactId>velocity</artifactId>
+                <version>${velocity.version}</version>
+            </dependency>
 
             <!-- Database connectivity -->
             <dependency>
@@ -321,6 +335,11 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
                 <version>${hibernate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.solr</groupId>
+                <artifactId>solr-solrj</artifactId>
+                <version>${solr4j.version}</version>
             </dependency>
 
             <!-- Formats -->
@@ -359,6 +378,11 @@
                 <artifactId>dans-bag-lib_2.12</artifactId>
                 <version>${dans-bag-lib.version}</version>
             </dependency>
+            <dependency>
+                <groupId>jaxen</groupId>
+                <artifactId>jaxen</artifactId>
+                <version>${jaxen.version}</version>
+            </dependency>
 
             <!-- Unit testing -->
             <dependency>
@@ -384,6 +408,11 @@
                 <artifactId>powermock-module-junit4-rule</artifactId>
                 <version>${powermock.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>mockwebserver</artifactId>
+                <version>${mockwebserver.version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -42,7 +42,7 @@
         <scala-xml.version>2.0.0-M1</scala-xml.version>
         <scalaj-http.version>2.4.2</scalaj-http.version>
         <scala-arm.version>2.0</scala-arm.version>
-        <dans-scala-lib.version>1.6.2-SNAPSHOT</dans-scala-lib.version>
+        <dans-scala-lib.version>1.6.2</dans-scala-lib.version>
         <better-files.version>3.8.0</better-files.version>
         <cats-core.version>2.1.1</cats-core.version>
 
@@ -88,7 +88,7 @@
         <jgit.version>5.6.1.202002131546-r</jgit.version>
         <json4s.version>3.7.0-M2</json4s.version>
         <tika.version>1.23</tika.version>
-        <dans-bag-lib.version>1.0.0-SNAPSHOT</dans-bag-lib.version>
+        <dans-bag-lib.version>1.0.0</dans-bag-lib.version>
         <jaxen.version>1.2.0</jaxen.version>
 
         <!-- Unit testing -->

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-mvn-plugin-defaults</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../dans-mvn-plugin-defaults</relativePath>
     </parent>
     <artifactId>dans-mvn-lib-defaults</artifactId>
     <name>DANS Maven Project Library Defaults</name>
-    <version>5.1.4-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         Defines the default configuration and version for libraries used in DANS projects.
@@ -37,68 +37,68 @@
     </scm>
     <properties>
         <!-- Scala -->
-        <scallop.version>3.1.5</scallop.version>
-        <scalarx.version>0.26.5</scalarx.version>
-        <scala-xml.version>1.1.1</scala-xml.version>
-        <scalaj-http.version>2.4.1</scalaj-http.version>
+        <scallop.version>3.3.2</scallop.version>
+        <scalarx.version>0.27.0</scalarx.version>
+        <scala-xml.version>2.0.0-M1</scala-xml.version>
+        <scalaj-http.version>2.4.2</scalaj-http.version>
         <scala-arm.version>2.0</scala-arm.version>
-        <dans-scala-lib.version>1.4.1</dans-scala-lib.version>
-        <better-files.version>3.6.0</better-files.version>
-        <cats-core.version>1.5.0</cats-core.version>
+        <dans-scala-lib.version>1.6.1</dans-scala-lib.version>
+        <better-files.version>3.8.0</better-files.version>
+        <cats-core.version>2.1.0</cats-core.version>
 
         <!-- Logging -->
-        <logback.version>1.2.3</logback.version>
-        <slf4j.version>1.7.25</slf4j.version>
-        <scala-logging.version>3.9.0</scala-logging.version>
-        <sourcecode.version>0.1.4</sourcecode.version>
+        <logback.version>1.3.0-alpha5</logback.version>
+        <slf4j.version>2.0.0-alpha1</slf4j.version>
+        <scala-logging.version>3.9.2</scala-logging.version>
+        <sourcecode.version>0.2.1</sourcecode.version>
         <logback-journal.version>0.3.0</logback-journal.version>
 
         <!-- Apache Commons -->
-        <commons-io.version>2.4</commons-io.version>
-        <commons-codec.version>1.10</commons-codec.version>
+        <commons-io.version>2.6</commons-io.version>
+        <commons-codec.version>1.14</commons-codec.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-configuration.version>1.10</commons-configuration.version>
-        <commons-csv.version>1.1</commons-csv.version>
-        <commons-daemon.version>1.0.15</commons-daemon.version>
-        <commons-dbcp2.version>2.1.1</commons-dbcp2.version>
-        <commons-compress.version>1.19</commons-compress.version>
+        <commons-csv.version>1.8</commons-csv.version>
+        <commons-daemon.version>1.2.2</commons-daemon.version>
+        <commons-dbcp2.version>2.7.0</commons-dbcp2.version>
+        <commons-compress.version>1.20</commons-compress.version>
         <commons-fileupload.version>1.4</commons-fileupload.version>
 
         <!-- ISO 8601 datetime -->
-        <joda-time.version>2.7</joda-time.version>
-        <joda-convert.version>1.6</joda-convert.version>
+        <joda-time.version>2.10.5</joda-time.version>
+        <joda-convert.version>2.2.1</joda-convert.version>
 
         <!-- HTTP server support -->
         <jetty.version>9.4.18.v20190429</jetty.version>
-        <scalatra.version>2.6.3</scalatra.version>
-        <guava.version>28.1-jre</guava.version>
+        <scalatra.version>2.7.0-RC1</scalatra.version>
+        <guava.version>28.2-jre</guava.version>
 
         <!-- Database connectivity -->
-        <postgresql.version>9.4-1205-jdbc42</postgresql.version>
-        <sqlite.version>3.21.0</sqlite.version>
-        <hsqldb.version>2.4.1</hsqldb.version>
-        <hibernate.version>4.3.11.Final</hibernate.version>
+        <postgresql.version>42.2.10.jre7</postgresql.version>
+        <sqlite.version>3.30.1</sqlite.version>
+        <hsqldb.version>2.5.0</hsqldb.version>
+        <hibernate.version>6.0.0.Alpha4</hibernate.version>
 
         <!-- Formats -->
-        <bagit.version>5.1.1</bagit.version>
-        <zip4j.version>1.3.2</zip4j.version>
-        <jgit.version>4.1.0.201509280440-r</jgit.version>
-        <json4s.version>3.5.3</json4s.version>
-        <tika.version>1.22</tika.version>
+        <bagit.version>5.2.0</bagit.version>
+        <zip4j.version>2.3.2</zip4j.version>
+        <jgit.version>5.6.1.202002131546-r</jgit.version>
+        <json4s.version>3.7.0-M2</json4s.version>
+        <tika.version>1.23</tika.version>
 
         <!-- Unit testing -->
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13</junit.version>
         <junit-addons.version>1.4</junit-addons.version>
-        <easymock.version>3.1</easymock.version>
-        <powermock.version>1.6.2</powermock.version>
+        <easymock.version>4.2</easymock.version>
+        <powermock.version>2.0.5</powermock.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <scala-test.version>3.0.5</scala-test.version>
-        <scalamock.version>4.1.0</scalamock.version>
-        <scalacheck.version>1.14.0</scalacheck.version>
-        <cats-scalatest.version>2.4.0</cats-scalatest.version>
+        <scala-test.version>3.2.0-SNAP10</scala-test.version>
+        <scalamock.version>4.4.0</scalamock.version>
+        <scalacheck.version>1.14.3</scalacheck.version>
+        <cats-scalatest.version>3.0.5</cats-scalatest.version>
 
         <!-- LEGACY -->
-        <spring.version>5.1.1.RELEASE</spring.version>
+        <spring.version>5.2.3.RELEASE</spring.version>
         <yourmediashelf.version>0.7</yourmediashelf.version>
         <!--
             According to mvnrepository.com the eclipse branch of jetty is the "current" one.

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -42,7 +42,7 @@
         <scala-xml.version>2.0.0-M1</scala-xml.version>
         <scalaj-http.version>2.4.2</scalaj-http.version>
         <scala-arm.version>2.0</scala-arm.version>
-        <dans-scala-lib.version>1.6.1</dans-scala-lib.version>
+        <dans-scala-lib.version>1.6.2-SNAPSHOT</dans-scala-lib.version>
         <better-files.version>3.8.0</better-files.version>
         <cats-core.version>2.1.1</cats-core.version>
 
@@ -71,7 +71,7 @@
         <!-- HTTP server support -->
         <jetty.version>9.4.18.v20190429</jetty.version>
         <javax-servlet-api.version>4.0.1</javax-servlet-api.version>
-        <scalatra.version>2.7.0</scalatra.version>
+        <scalatra.version>2.7.0-RC1</scalatra.version>
         <guava.version>28.2-jre</guava.version>
 
         <!-- Database connectivity -->
@@ -86,6 +86,7 @@
         <jgit.version>5.6.1.202002131546-r</jgit.version>
         <json4s.version>3.7.0-M2</json4s.version>
         <tika.version>1.23</tika.version>
+        <dans-bag-lib.version>1.0.0-SNAPSHOT</dans-bag-lib.version>
 
         <!-- Unit testing -->
         <junit.version>4.13</junit.version>
@@ -352,6 +353,11 @@
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
                 <version>${tika.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>nl.knaw.dans.lib</groupId>
+                <artifactId>dans-bag-lib_2.12</artifactId>
+                <version>${dans-bag-lib.version}</version>
             </dependency>
 
             <!-- Unit testing -->

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -76,27 +76,27 @@
         <velocity.version>1.7</velocity.version>
 
         <!-- Database connectivity -->
-        <postgresql.version>42.2.10.jre7</postgresql.version>
+        <postgresql.version>42.2.11.jre7</postgresql.version>
         <sqlite.version>3.30.1</sqlite.version>
         <hsqldb.version>2.5.0</hsqldb.version>
         <hibernate.version>5.4.12.Final</hibernate.version>
-        <solr4j.version>6.6.0</solr4j.version>
+        <solr4j.version>8.4.1</solr4j.version>
 
         <!-- Formats -->
         <bagit.version>5.2.0</bagit.version>
-        <zip4j.version>2.4.0</zip4j.version>
+        <zip4j.version>2.5.0</zip4j.version>
         <jgit.version>5.7.0.202003090808-r</jgit.version>
-        <json4s.version>3.6.7</json4s.version>
+        <json4s.version>3.7.0-M2</json4s.version>
         <tika.version>1.23</tika.version>
         <dans-bag-lib.version>1.0.0</dans-bag-lib.version>
-        <jaxen.version>1.2.0</jaxen.version>
+        <jaxen.version>1.2.0-atlassian-2</jaxen.version>
 
         <!-- Unit testing -->
         <junit.version>4.13</junit.version>
         <junit-addons.version>1.4</junit-addons.version>
         <easymock.version>4.2</easymock.version>
         <powermock.version>2.0.5</powermock.version>
-        <mockwebserver.version>4.4.0</mockwebserver.version>
+        <mockwebserver.version>4.4.1</mockwebserver.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- Do not update untill this issue is resolved: https://github.com/scalatest/scalatest/issues/1734 -->
         <scala-test.version>3.0.8</scala-test.version> 

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -39,7 +39,7 @@
         <!-- Scala -->
         <scallop.version>3.4.0</scallop.version>
         <scalarx.version>0.27.0</scalarx.version>
-        <scala-xml.version>2.0.0-M1</scala-xml.version>
+        <scala-xml.version>1.2.0</scala-xml.version>
         <scalaj-http.version>2.4.2</scalaj-http.version>
         <scala-arm.version>2.0</scala-arm.version>
         <dans-scala-lib.version>1.6.2</dans-scala-lib.version>
@@ -47,8 +47,8 @@
         <cats-core.version>2.1.1</cats-core.version>
 
         <!-- Logging -->
-        <logback.version>1.3.0-alpha5</logback.version>
-        <slf4j.version>2.0.0-alpha1</slf4j.version>
+        <logback.version>1.2.3</logback.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <scala-logging.version>3.9.2</scala-logging.version>
         <sourcecode.version>0.2.1</sourcecode.version>
         <logback-journal.version>0.3.0</logback-journal.version>
@@ -71,7 +71,7 @@
         <!-- HTTP server support -->
         <jetty.version>9.4.18.v20190429</jetty.version>
         <javax-servlet-api.version>4.0.1</javax-servlet-api.version>
-        <scalatra.version>2.7.0-RC1</scalatra.version>
+        <scalatra.version>2.6.5</scalatra.version>
         <guava.version>28.2-jre</guava.version>
         <velocity.version>1.7</velocity.version>
 
@@ -79,14 +79,14 @@
         <postgresql.version>42.2.10.jre7</postgresql.version>
         <sqlite.version>3.30.1</sqlite.version>
         <hsqldb.version>2.5.0</hsqldb.version>
-        <hibernate.version>6.0.0.Alpha4</hibernate.version>
+        <hibernate.version>5.4.12.Final</hibernate.version>
         <solr4j.version>6.6.0</solr4j.version>
 
         <!-- Formats -->
         <bagit.version>5.2.0</bagit.version>
         <zip4j.version>2.4.0</zip4j.version>
-        <jgit.version>5.6.1.202002131546-r</jgit.version>
-        <json4s.version>3.7.0-M2</json4s.version>
+        <jgit.version>5.7.0.202003090808-r</jgit.version>
+        <json4s.version>3.6.7</json4s.version>
         <tika.version>1.23</tika.version>
         <dans-bag-lib.version>1.0.0</dans-bag-lib.version>
         <jaxen.version>1.2.0</jaxen.version>

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -37,14 +37,14 @@
     </scm>
     <properties>
         <!-- Scala -->
-        <scallop.version>3.3.2</scallop.version>
+        <scallop.version>3.4.0</scallop.version>
         <scalarx.version>0.27.0</scalarx.version>
         <scala-xml.version>2.0.0-M1</scala-xml.version>
         <scalaj-http.version>2.4.2</scalaj-http.version>
         <scala-arm.version>2.0</scala-arm.version>
         <dans-scala-lib.version>1.6.1</dans-scala-lib.version>
         <better-files.version>3.8.0</better-files.version>
-        <cats-core.version>2.1.0</cats-core.version>
+        <cats-core.version>2.1.1</cats-core.version>
 
         <!-- Logging -->
         <logback.version>1.3.0-alpha5</logback.version>
@@ -71,7 +71,7 @@
         <!-- HTTP server support -->
         <jetty.version>9.4.18.v20190429</jetty.version>
         <javax-servlet-api.version>4.0.1</javax-servlet-api.version>
-        <scalatra.version>2.7.0-RC1</scalatra.version>
+        <scalatra.version>2.7.0</scalatra.version>
         <guava.version>28.2-jre</guava.version>
 
         <!-- Database connectivity -->
@@ -82,7 +82,7 @@
 
         <!-- Formats -->
         <bagit.version>5.2.0</bagit.version>
-        <zip4j.version>2.3.2</zip4j.version>
+        <zip4j.version>2.4.0</zip4j.version>
         <jgit.version>5.6.1.202002131546-r</jgit.version>
         <json4s.version>3.7.0-M2</json4s.version>
         <tika.version>1.23</tika.version>
@@ -100,7 +100,7 @@
         <cats-scalatest.version>3.0.5</cats-scalatest.version>
 
         <!-- LEGACY -->
-        <spring.version>5.2.3.RELEASE</spring.version>
+        <spring.version>5.2.4.RELEASE</spring.version>
         <yourmediashelf.version>0.7</yourmediashelf.version>
         <!--
             According to mvnrepository.com the eclipse branch of jetty is the "current" one.

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -70,6 +70,7 @@
 
         <!-- HTTP server support -->
         <jetty.version>9.4.18.v20190429</jetty.version>
+        <javax-servlet-api.version>4.0.1</javax-servlet-api.version>
         <scalatra.version>2.7.0-RC1</scalatra.version>
         <guava.version>28.2-jre</guava.version>
 
@@ -92,7 +93,8 @@
         <easymock.version>4.2</easymock.version>
         <powermock.version>2.0.5</powermock.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <scala-test.version>3.0.8</scala-test.version>
+        <!-- Do not update untill this issue is resolved: https://github.com/scalatest/scalatest/issues/1734 -->
+        <scala-test.version>3.0.8</scala-test.version> 
         <scalamock.version>4.4.0</scalamock.version>
         <scalacheck.version>1.14.3</scalacheck.version>
         <cats-scalatest.version>3.0.5</cats-scalatest.version>
@@ -266,6 +268,11 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
                 <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>${javax-servlet-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.scalaj</groupId>

--- a/dans-mvn-plugin-defaults/pom.xml
+++ b/dans-mvn-plugin-defaults/pom.xml
@@ -177,6 +177,7 @@
                     </executions>
                     <configuration>
                         <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
+                        <scalaVersion>${scala.version}</scalaVersion>
                         <args>
                             <arg>-target:jvm-1.8</arg>
                             <arg>-deprecation</arg>

--- a/dans-mvn-plugin-defaults/pom.xml
+++ b/dans-mvn-plugin-defaults/pom.xml
@@ -46,7 +46,7 @@
         <scalatest-maven-plugin.version>2.0.0</scalatest-maven-plugin.version>
 
         <!-- Building binaries and source packages -->
-        <maven-compiler-plugin.version>3.8.1-jboss-1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <java.version>1.6</java.version><!-- Still using Java 1.6 as default, for legacy projects -->
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>

--- a/dans-mvn-plugin-defaults/pom.xml
+++ b/dans-mvn-plugin-defaults/pom.xml
@@ -42,11 +42,11 @@
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala-maven-plugin.version>4.3.1</scala-maven-plugin.version>
-        <kind-projector-compiler-plugin.version>0.9.9</kind-projector-compiler-plugin.version>
+        <kind-projector-compiler-plugin.version>0.11.0</kind-projector-compiler-plugin.version>
         <scalatest-maven-plugin.version>2.0.0</scalatest-maven-plugin.version>
 
         <!-- Building binaries and source packages -->
-        <maven-compiler-plugin.version>3.8.1-jboss-1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <java.version>1.6</java.version><!-- Still using Java 1.6 as default, for legacy projects -->
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
@@ -177,7 +177,6 @@
                     </executions>
                     <configuration>
                         <scalaCompatVersion>${scala.binary.version}</scalaCompatVersion>
-                        <scalaVersion>${scala.version}</scalaVersion>
                         <args>
                             <arg>-target:jvm-1.8</arg>
                             <arg>-deprecation</arg>
@@ -185,8 +184,8 @@
                         </args>
                         <compilerPlugins>
                             <compilerPlugin>
-                                <groupId>org.spire-math</groupId>
-                                <artifactId>kind-projector_2.12</artifactId>
+                                <groupId>org.typelevel</groupId>
+                                <artifactId>kind-projector_2.12.10</artifactId>
                                 <version>${kind-projector-compiler-plugin.version}</version>
                             </compilerPlugin>
                         </compilerPlugins>

--- a/dans-mvn-plugin-defaults/pom.xml
+++ b/dans-mvn-plugin-defaults/pom.xml
@@ -39,7 +39,7 @@
         <!-- Build resources support -->
         <dans-mvn-build-resources.version>4.0.1</dans-mvn-build-resources.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-        <scala.version>2.12.3</scala.version>
+        <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala-maven-plugin.version>4.3.1</scala-maven-plugin.version>
         <kind-projector-compiler-plugin.version>0.9.9</kind-projector-compiler-plugin.version>

--- a/dans-mvn-plugin-defaults/pom.xml
+++ b/dans-mvn-plugin-defaults/pom.xml
@@ -415,17 +415,16 @@
                                     </softlinkSource>
                                 </sources>
                             </mapping>
-                            <defineStatements>
-                                <!--
-                                    To prevent the following problem from occurring:
-                                    https://github.com/DANS-KNAW/easy-dtap#problem-building-rpm
-
-                                    Somehow this macro was not defined on some developers' systems and they had to work around it by
-                                    defining it in ~/.rpmmacros. This should no longer be necessary.
-                                -->
-                                <defineStatement>_tmppath %{_topdir}/BUILD</defineStatement>
-                            </defineStatements>
                         </mappings>
+                        <defineStatements>
+                            <!--
+                                To prevent the following problem from occurring:
+                                https://github.com/DANS-KNAW/easy-dtap#problem-building-rpm
+                                Somehow this macro was not defined on some developers' systems and they had to work around it by
+                                defining it in ~/.rpmmacros. This should no longer be necessary.
+                            -->
+                            <defineStatement>_tmppath %{_topdir}/BUILD</defineStatement>
+                        </defineStatements>
                         <!-- Build-time scripts -->
                         <prepareScriptlet>
                             <scriptFile>target/dans-rpm-scripts/build-0-prepare.sh</scriptFile>

--- a/dans-mvn-plugin-defaults/pom.xml
+++ b/dans-mvn-plugin-defaults/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-mvn-base</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../dans-mvn-base</relativePath>
     </parent>
     <artifactId>dans-mvn-plugin-defaults</artifactId>
     <name>DANS Maven Project Plug-In Defaults</name>
-    <version>5.1.4-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>
         Defines the default configuration and version for plug-ins used in DANS projects.
@@ -38,48 +38,48 @@
     <properties>
         <!-- Build resources support -->
         <dans-mvn-build-resources.version>4.0.1</dans-mvn-build-resources.version>
-        <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
         <scala.version>2.12.3</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <scala-maven-plugin.version>3.4.6</scala-maven-plugin.version>
+        <scala-maven-plugin.version>4.3.1</scala-maven-plugin.version>
         <kind-projector-compiler-plugin.version>0.9.9</kind-projector-compiler-plugin.version>
-        <scalatest-maven-plugin.version>1.0</scalatest-maven-plugin.version>
+        <scalatest-maven-plugin.version>2.0.0</scalatest-maven-plugin.version>
 
         <!-- Building binaries and source packages -->
-        <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.8.1-jboss-1</maven-compiler-plugin.version>
         <java.version>1.6</java.version><!-- Still using Java 1.6 as default, for legacy projects -->
-        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-        <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-        <maven-war-plugin.version>2.6</maven-war-plugin.version>
-        <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+        <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
 
         <!-- Assembling installables -->
         <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
-        <rpm-maven-plugin.version>2.1.5</rpm-maven-plugin.version>
+        <rpm-maven-plugin.version>2.2.0</rpm-maven-plugin.version>
         <rpm-release /><!-- Only declared here, override on the command line if you need a custom release for the RPM -->
         <dans-provider-name>dans.knaw.nl</dans-provider-name>
         <rpm-replace-configuration>true</rpm-replace-configuration> <!-- Change to noreplace  if you want to support automatically upgrading config files in post install scripts -->
         <main-class>NoMainClass</main-class><!-- Only a placeholder is declared here. The inheriting project should fill in the FQN of the main class -->
-        <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
+        <maven-assembly-plugin.version>3.2.0</maven-assembly-plugin.version>
 
         <!-- Distributing installables -->
         <rpm-snapshot-repository>http://nexus.dans.knaw.nl/repository/rpm-snapshots</rpm-snapshot-repository>
         <rpm-release-repository>http://nexus.dans.knaw.nl/repository/rpm-releases</rpm-release-repository>
 
         <!-- Debugging -->
-        <exec-maven-plugin.version>1.4.0</exec-maven-plugin.version>
+        <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
 
         <!-- Static code analysis -->
         <scalastyle-maven-plugin.version>1.0.0</scalastyle-maven-plugin.version>
 
         <!-- Legacy -->
-        <aspectj-maven-plugin.version>1.4</aspectj-maven-plugin.version>
-        <build-helper-maven-plugin.version>1.8</build-helper-maven-plugin.version>
-        <maven-jibx-plugin.version>1.2.5</maven-jibx-plugin.version>
-        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
+        <aspectj-maven-plugin.version>1.11</aspectj-maven-plugin.version>
+        <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
+        <maven-jibx-plugin.version>1.3.1</maven-jibx-plugin.version>
+        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
         <maven-java-formatter-plugin.version>0.4</maven-java-formatter-plugin.version>
-        <maven-site-plugin.version>3.7</maven-site-plugin.version>
+        <maven-site-plugin.version>3.8.2</maven-site-plugin.version>
     </properties>
     <repositories>
         <repository>

--- a/dans-mvn-plugin-defaults/pom.xml
+++ b/dans-mvn-plugin-defaults/pom.xml
@@ -46,7 +46,7 @@
         <scalatest-maven-plugin.version>2.0.0</scalatest-maven-plugin.version>
 
         <!-- Building binaries and source packages -->
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.8.1-jboss-1</maven-compiler-plugin.version>
         <java.version>1.6</java.version><!-- Still using Java 1.6 as default, for legacy projects -->
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>

--- a/dans-scala-app-project/pom.xml
+++ b/dans-scala-app-project/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-project</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../dans-scala-project</relativePath>
     </parent>
 
     <artifactId>dans-scala-app-project</artifactId>
-    <version>5.1.4-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <name>DANS Scala Application Project</name>
     <packaging>pom</packaging>
     <scm>

--- a/dans-scala-project/pom.xml
+++ b/dans-scala-project/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-mvn-lib-defaults</artifactId>
-        <version>5.1.4-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../dans-mvn-lib-defaults</relativePath>
     </parent>
 
     <artifactId>dans-scala-project</artifactId>
-    <version>5.1.4-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <name>DANS Scala Project</name>
     <description>
         A bare bones Scala-based project. The best choice when creating a Scala based library.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <tag>HEAD</tag>
     </scm>
     <properties>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
     </properties>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>nl.knaw.dans.shared</groupId>
     <artifactId>dans-parent-pom</artifactId>
     <name>DANS Maven Parents Master Build</name>
-    <version>5.1.7-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>


### PR DESCRIPTION
* updated all dependencies to latest versions (as of `11-03-2020`) by execution of `mvn versions:update-properties`.
* manually updated `kind-projector` from version `0.9.9` to `0.11.0` (group id changed).
* added the following dependencies to `dans-mvn-lib-defaults`: `jul-to-slf4j`, `javax.servlet-api`, `velocity`, `solr-solrj`, `dans-bag-lib_2.12`, `jaxen`, `mockwebserver`.
* changed `scalatest` version from `3.2.0-M4` to `3.0.8` due to this issue: https://github.com/scalatest/scalatest/issues/1734 .
* changed `scalatra` version from `2.7.0` to `2.6.5` due to its dependency a newer `scalatest`.
* documented the workaround discussed for circular dependencies.
* changed alpha/milestone versions introduced to their last stable versions.
