### PR TITLE
EASY-2717: Dependency upgrades

### DIFF
--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -83,7 +83,7 @@
         <solr4j.version>8.5.1</solr4j.version>
 
         <!-- Formats -->
-        <bagit.version>5.2.0</bagit.version>
+        <bagit.version>5.4.0</bagit.version>
         <zip4j.version>2.5.2</zip4j.version>
         <jgit.version>5.7.0.202003110725-r</jgit.version>
         <dans-bag-lib.version>1.0.1</dans-bag-lib.version>
@@ -344,7 +344,7 @@
 
             <!-- Formats -->
             <dependency>
-                <groupId>gov.loc</groupId>
+                <groupId>nl.knaw.dans</groupId>
                 <artifactId>bagit</artifactId>
                 <version>${bagit.version}</version>
             </dependency>

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -39,7 +39,7 @@
         <!-- Scala -->
         <scallop.version>3.4.0</scallop.version>
         <scalarx.version>0.27.0</scalarx.version>
-        <scala-xml.version>1.2.0</scala-xml.version>
+        <scala-xml.version>1.3.0</scala-xml.version>
         <scalaj-http.version>2.4.2</scalaj-http.version>
         <scala-arm.version>2.0</scala-arm.version>
         <dans-scala-lib.version>1.6.3</dans-scala-lib.version>
@@ -65,30 +65,30 @@
         <commons-fileupload.version>1.4</commons-fileupload.version>
 
         <!-- ISO 8601 datetime -->
-        <joda-time.version>2.10.5</joda-time.version>
+        <joda-time.version>2.10.6</joda-time.version>
         <joda-convert.version>2.2.1</joda-convert.version>
 
         <!-- HTTP server support -->
         <jetty.version>9.4.18.v20190429</jetty.version>
         <javax-servlet-api.version>4.0.1</javax-servlet-api.version>
         <scalatra.version>2.7.0</scalatra.version>
-        <guava.version>28.2-jre</guava.version>
+        <guava.version>29.0-jre</guava.version>
         <velocity.version>1.7</velocity.version>
 
         <!-- Database connectivity -->
         <postgresql.version>42.2.12.jre7</postgresql.version>
-        <sqlite.version>3.30.1</sqlite.version>
+        <sqlite.version>3.31.1</sqlite.version>
         <hsqldb.version>2.5.0</hsqldb.version>
         <hibernate.version>5.4.12.Final</hibernate.version>
-        <solr4j.version>8.5.0</solr4j.version>
+        <solr4j.version>8.5.1</solr4j.version>
 
         <!-- Formats -->
         <bagit.version>5.2.0</bagit.version>
-        <zip4j.version>2.5.1</zip4j.version>
+        <zip4j.version>2.5.2</zip4j.version>
         <jgit.version>5.7.0.202003110725-r</jgit.version>
-        <json4s.version>3.7.0-M2</json4s.version>
-        <tika.version>1.24</tika.version>
         <dans-bag-lib.version>1.0.1</dans-bag-lib.version>
+        <json4s.version>3.7.0-M4</json4s.version>
+        <tika.version>1.24.1</tika.version>
         <jaxen.version>1.2.0</jaxen.version>
 
         <!-- Unit testing -->
@@ -96,7 +96,7 @@
         <junit-addons.version>1.4</junit-addons.version>
         <easymock.version>4.2</easymock.version>
         <powermock.version>2.0.7</powermock.version>
-        <mockwebserver.version>4.4.1</mockwebserver.version>
+        <mockwebserver.version>4.6.0</mockwebserver.version>
         <hamcrest.version>1.3</hamcrest.version>
         <scala-test.version>3.1.1</scala-test.version> 
         <scalamock.version>4.4.0</scalamock.version>
@@ -105,7 +105,7 @@
         <cats-scalatest.version>3.0.5</cats-scalatest.version>
 
         <!-- LEGACY -->
-        <spring.version>5.2.5.RELEASE</spring.version>
+        <spring.version>5.2.6.RELEASE</spring.version>
         <yourmediashelf.version>0.7</yourmediashelf.version>
         <!--
             According to mvnrepository.com the eclipse branch of jetty is the "current" one.

--- a/dans-mvn-lib-defaults/pom.xml
+++ b/dans-mvn-lib-defaults/pom.xml
@@ -42,7 +42,7 @@
         <scala-xml.version>1.3.0</scala-xml.version>
         <scalaj-http.version>2.4.2</scalaj-http.version>
         <scala-arm.version>2.0</scala-arm.version>
-        <dans-scala-lib.version>1.6.3</dans-scala-lib.version>
+        <dans-scala-lib.version>1.6.4</dans-scala-lib.version>
         <better-files.version>3.8.0</better-files.version>
         <cats-core.version>2.1.1</cats-core.version>
 
@@ -86,9 +86,9 @@
         <bagit.version>5.4.0</bagit.version>
         <zip4j.version>2.5.2</zip4j.version>
         <jgit.version>5.7.0.202003110725-r</jgit.version>
-        <dans-bag-lib.version>1.0.1</dans-bag-lib.version>
         <json4s.version>3.7.0-M4</json4s.version>
         <tika.version>1.24.1</tika.version>
+        <dans-bag-lib.version>1.0.2</dans-bag-lib.version>
         <jaxen.version>1.2.0</jaxen.version>
 
         <!-- Unit testing -->

--- a/dans-mvn-plugin-defaults/pom.xml
+++ b/dans-mvn-plugin-defaults/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <!-- Build resources support -->
         <dans-mvn-build-resources.version>4.0.1</dans-mvn-build-resources.version>
-        <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala-maven-plugin.version>4.3.1</scala-maven-plugin.version>
@@ -55,13 +55,13 @@
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
 
         <!-- Assembling installables -->
-        <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
+        <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
         <rpm-maven-plugin.version>2.2.0</rpm-maven-plugin.version>
         <rpm-release /><!-- Only declared here, override on the command line if you need a custom release for the RPM -->
         <dans-provider-name>dans.knaw.nl</dans-provider-name>
         <rpm-replace-configuration>true</rpm-replace-configuration> <!-- Change to noreplace  if you want to support automatically upgrading config files in post install scripts -->
         <main-class>NoMainClass</main-class><!-- Only a placeholder is declared here. The inheriting project should fill in the FQN of the main class -->
-        <maven-assembly-plugin.version>3.2.0</maven-assembly-plugin.version>
+        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
 
         <!-- Distributing installables -->
         <rpm-snapshot-repository>http://nexus.dans.knaw.nl/repository/rpm-snapshots</rpm-snapshot-repository>
@@ -75,11 +75,11 @@
 
         <!-- Legacy -->
         <aspectj-maven-plugin.version>1.11</aspectj-maven-plugin.version>
-        <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
+        <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <maven-jibx-plugin.version>1.3.1</maven-jibx-plugin.version>
-        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-java-formatter-plugin.version>0.4</maven-java-formatter-plugin.version>
-        <maven-site-plugin.version>3.8.2</maven-site-plugin.version>
+        <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
     </properties>
     <repositories>
         <repository>

--- a/dans-mvn-plugin-defaults/pom.xml
+++ b/dans-mvn-plugin-defaults/pom.xml
@@ -182,6 +182,7 @@
                             <arg>-target:jvm-1.8</arg>
                             <arg>-deprecation</arg>
                             <arg>-feature</arg>
+                            <arg>-Ypartial-unification</arg>
                         </args>
                         <compilerPlugins>
                             <compilerPlugin>


### PR DESCRIPTION
Fixes issue EASY-2717

#### When applied it will
* apply random dependency upgrades
* upgrade `bagit-java` from `v5.2.0` to `v5.4.0` and change the `groupId` from `gov.loc` to `nl.knaw.dans`
* enable partial unification on Scala compiler to better support the `cats` library
* upgrade `dans-scala-lib` and `dans-bag-lib` dependencies to the next build versions

@DANS-KNAW/easy for review